### PR TITLE
fixed nulltime unmarshalling into zero time utc

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -10,8 +10,8 @@ CREATE TABLE `common_cases` (
   `not_null_int` int(11) NOT NULL,
   `null_string` int(11) DEFAULT NULL,
   `null_int` int(11) DEFAULT NULL,
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` int(11) DEFAULT NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -21,5 +21,6 @@ CREATE TABLE `complex_cases` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `raw_json` json NOT NULL,
   `size_enum` enum('X-SMALL','SMALL','MEDIUM','LARGE','X-LARGE') DEFAULT NULL,
+  `updated_at` TIMESTAMP NULL DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tmpl/x_helpers.html
+++ b/tmpl/x_helpers.html
@@ -271,21 +271,31 @@ func (n NullTime) Value() (driver.Value, error) {
 
 // UnmarshalJSON for NullTime
 func (n *NullTime) UnmarshalJSON(b []byte) error {
-	s := string(b)
-	s = strings.Trim(s, `"`)
+    s := string(b)
+    s = strings.Trim(s, `"`)
 
-	var tim time.Time
-	if !strings.EqualFold(s, "null") {
-		var err error
-		if tim, err = time.Parse(time.RFC3339, s); err != nil {
-			n.Valid = false
-			return err
-		}
-	}
+    var (
+        zeroTime time.Time
+        tim      time.Time
+        err      error
+    )
 
-	n.Time = tim
-	n.Valid = true
-	return nil
+    if strings.EqualFold(s, "null") {
+        return nil
+    }
+
+    if tim, err = time.Parse(time.RFC3339, s); err != nil {
+        n.Valid = false
+        return err
+    }
+
+    if tim == zeroTime {
+        return nil
+    }
+
+    n.Time = tim
+    n.Valid = true
+    return nil
 }
 
 // Scan for NullTime


### PR DESCRIPTION
When a zero time is umarshalled, it would not be marked as an invalid `NullTime`, this means that any subsquent marhsalling of it results in printing a zero time rather than the explicit (and expected) `null`